### PR TITLE
[DNM] RTG-2051 Add X25519Kyber{512,768}Draft00 hybrid post-quantum key exchange

### DIFF
--- a/cfkem.go
+++ b/cfkem.go
@@ -1,0 +1,175 @@
+// Copyright 2023 Cloudflare, Inc. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+//
+// Glue to add Circl's (post-quantum) hybrid KEMs.
+//
+// To enable set CurvePreferences with the desired scheme as the first element:
+//
+//   import (
+//      "github.com/cloudflare/circl/kem/tls"
+//      "github.com/cloudflare/circl/kem/hybrid"
+//
+//          [...]
+//
+//   config.CurvePreferences = []tls.CurveID{
+//      qtls.X25519Kyber512Draft00,
+//      qtls.X25519,
+//      qtls.P256,
+//   }
+
+package qtls
+
+import (
+	"github.com/cloudflare/circl/kem"
+	"github.com/cloudflare/circl/kem/hybrid"
+
+	"crypto/ecdh"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// Either *ecdh.PrivateKey or kem.PrivateKey
+type clientKeySharePrivate interface{}
+
+var (
+	X25519Kyber512Draft00 = CurveID(0xfe30)
+	X25519Kyber768Draft00 = CurveID(0xfe31)
+	invalidCurveID        = CurveID(0)
+)
+
+func kemSchemeKeyToCurveID(s kem.Scheme) CurveID {
+	switch s.Name() {
+	case "Kyber512-X25519":
+		return X25519Kyber512Draft00
+	case "Kyber768-X25519":
+		return X25519Kyber768Draft00
+	default:
+		return invalidCurveID
+	}
+}
+
+// Extract CurveID from clientKeySharePrivate
+func clientKeySharePrivateCurveID(ks clientKeySharePrivate) CurveID {
+	switch v := ks.(type) {
+	case kem.PrivateKey:
+		ret := kemSchemeKeyToCurveID(v.Scheme())
+		if ret == invalidCurveID {
+			panic("cfkem: internal error: don't know CurveID for this KEM")
+		}
+		return ret
+	case *ecdh.PrivateKey:
+		ret, ok := curveIDForCurve(v.Curve())
+		if !ok {
+			panic("cfkem: internal error: unknown curve")
+		}
+		return ret
+	default:
+		panic("cfkem: internal error: unknown clientKeySharePrivate")
+	}
+}
+
+// Returns scheme by CurveID if supported by Circl
+func curveIdToCirclScheme(id CurveID) kem.Scheme {
+	switch id {
+	case X25519Kyber512Draft00:
+		return hybrid.Kyber512X25519()
+	case X25519Kyber768Draft00:
+		return hybrid.Kyber768X25519()
+	}
+	return nil
+}
+
+// Generate a new shared secret and encapsulates it for the packed
+// public key in ppk using randomness from rnd.
+func encapsulateForKem(scheme kem.Scheme, rnd io.Reader, ppk []byte) (
+	ct, ss []byte, alert alert, err error) {
+	pk, err := scheme.UnmarshalBinaryPublicKey(ppk)
+	if err != nil {
+		return nil, nil, alertIllegalParameter, fmt.Errorf("unpack pk: %w", err)
+	}
+	seed := make([]byte, scheme.EncapsulationSeedSize())
+	if _, err := io.ReadFull(rnd, seed); err != nil {
+		return nil, nil, alertInternalError, fmt.Errorf("random: %w", err)
+	}
+	ct, ss, err = scheme.EncapsulateDeterministically(pk, seed)
+	return ct, ss, alertIllegalParameter, err
+}
+
+// Generate a new keypair using randomness from rnd.
+func generateKemKeyPair(scheme kem.Scheme, rnd io.Reader) (
+	kem.PublicKey, kem.PrivateKey, error) {
+	seed := make([]byte, scheme.SeedSize())
+	if _, err := io.ReadFull(rnd, seed); err != nil {
+		return nil, nil, err
+	}
+	pk, sk := scheme.DeriveKeyPair(seed)
+	return pk, sk, nil
+}
+
+// Events. We cannot use the same approach as used in our plain Go fork
+// as we cannot change tls.Config, tls.ConnectionState, etc. Also we do
+// not want to maintain a fork of quic-go itself as well. This seems
+// the simplest option.
+
+// CFEvent. There are two events: one emitted on HRR and one emitted
+type CFEvent interface {
+	// Common to all events
+	ServerSide() bool // true if server-side; false if on client-side
+
+	// HRR event. Emitted when an HRR happened.
+	IsHRR() bool // true if this is an HRR event
+
+	// Handshake event.
+	IsHandshake() bool       // true if this is a handshake event.
+	Duration() time.Duration // how long did the handshake take?
+	KEX() tls.CurveID        // which kex was established?
+}
+
+type CFEventHandler func(CFEvent)
+
+// Registers a handler to be called when a CFEvent is emitted; returns
+// the previous handler.
+func SetCFEventHandler(handler CFEventHandler) CFEventHandler {
+	cfEventMux.Lock()
+	ret := cfEventHandler
+	cfEventHandler = handler
+	cfEventMux.Unlock()
+	return ret
+}
+
+func raiseCFEvent(ev CFEvent) {
+	cfEventMux.Lock()
+	handler := cfEventHandler
+	cfEventMux.Unlock()
+	if handler != nil {
+		handler(ev)
+	}
+}
+
+var (
+	cfEventMux     sync.Mutex
+	cfEventHandler CFEventHandler
+)
+
+type cfEventHRR struct{ serverSide bool }
+
+func (*cfEventHRR) IsHRR() bool                { return true }
+func (ev *cfEventHRR) ServerSide() bool        { return ev.serverSide }
+func (*cfEventHRR) IsHandshake() bool          { return false }
+func (ev *cfEventHRR) Duration() time.Duration { panic("wrong event") }
+func (ev *cfEventHRR) KEX() tls.CurveID        { panic("wrong event") }
+
+type cfEventHandshake struct {
+	serverSide bool
+	duration   time.Duration
+	kex        tls.CurveID
+}
+
+func (*cfEventHandshake) IsHRR() bool                { return false }
+func (ev *cfEventHandshake) ServerSide() bool        { return ev.serverSide }
+func (*cfEventHandshake) IsHandshake() bool          { return true }
+func (ev *cfEventHandshake) Duration() time.Duration { return ev.duration }
+func (ev *cfEventHandshake) KEX() tls.CurveID        { return ev.kex }

--- a/cfkem_test.go
+++ b/cfkem_test.go
@@ -1,0 +1,134 @@
+// Copyright 2022 Cloudflare, Inc. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+package qtls
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/cloudflare/circl/kem"
+	"github.com/cloudflare/circl/kem/hybrid"
+)
+
+func testHybridKEX(t *testing.T, scheme kem.Scheme, clientPQ, serverPQ,
+	clientTLS12, serverTLS12 bool) {
+	var retry bool
+	var clientSelectedKEX *CurveID
+	var mux sync.Mutex
+
+	rsaCert := Certificate{
+		Certificate: [][]byte{testRSACertificate},
+		PrivateKey:  testRSAPrivateKey,
+	}
+	serverCerts := []Certificate{rsaCert}
+
+	clientConfig := testConfig.Clone()
+	if clientPQ {
+		clientConfig.CurvePreferences = []CurveID{
+			kemSchemeKeyToCurveID(scheme),
+			X25519,
+		}
+	}
+	if clientTLS12 {
+		clientConfig.MaxVersion = VersionTLS12
+	}
+	SetCFEventHandler(func(ev CFEvent) {
+		if !ev.ServerSide() {
+			return
+		}
+		if ev.IsHRR() {
+			retry = true
+			return
+		}
+		if ev.IsHandshake() {
+			kex := ev.KEX()
+			mux.Lock()
+			clientSelectedKEX = &kex
+			mux.Unlock()
+			return
+		}
+	})
+
+	serverConfig := testConfig.Clone()
+	if serverPQ {
+		serverConfig.CurvePreferences = []CurveID{
+			kemSchemeKeyToCurveID(scheme),
+			X25519,
+		}
+	}
+	if serverTLS12 {
+		serverConfig.MaxVersion = VersionTLS12
+	}
+	serverConfig.Certificates = serverCerts
+
+	c, s := localPipe(t)
+	done := make(chan error)
+	defer c.Close()
+
+	go func() {
+		defer s.Close()
+		done <- Server(s, serverConfig).Handshake()
+	}()
+
+	cli := Client(c, clientConfig)
+	clientErr := cli.Handshake()
+	serverErr := <-done
+	if clientErr != nil {
+		t.Errorf("client error: %s", clientErr)
+	}
+	if serverErr != nil {
+		t.Errorf("server error: %s", serverErr)
+	}
+
+	var expectedKEX CurveID
+	var expectedRetry bool
+
+	if clientPQ && serverPQ {
+		expectedKEX = kemSchemeKeyToCurveID(scheme)
+	} else {
+		expectedKEX = X25519
+	}
+	if clientPQ && !serverPQ {
+		expectedRetry = true
+	}
+
+	if !serverTLS12 && !clientTLS12 {
+		if clientSelectedKEX == nil {
+			t.Error("No TLS 1.3 KEX happened?")
+		}
+
+		if *clientSelectedKEX != expectedKEX {
+			t.Errorf("failed to negotiate: expected %d, got %d",
+				expectedKEX, *clientSelectedKEX)
+		}
+		if expectedRetry != retry {
+			t.Errorf("Expected retry=%v, got retry=%v", expectedRetry, retry)
+		}
+	} else {
+		if clientSelectedKEX != nil {
+			t.Error("TLS 1.3 KEX happened?")
+		}
+	}
+}
+
+func TestHybridKEX(t *testing.T) {
+	run := func(scheme kem.Scheme, clientPQ, serverPQ, clientTLS12, serverTLS12 bool) {
+		t.Run(fmt.Sprintf("%s serverPQ:%v clientPQ:%v serverTLS12:%v clientTLS12:%v", scheme.Name(),
+			serverPQ, clientPQ, serverTLS12, clientTLS12), func(t *testing.T) {
+			testHybridKEX(t, scheme, clientPQ, serverPQ, clientTLS12, serverTLS12)
+		})
+	}
+	for _, scheme := range []kem.Scheme{
+		hybrid.Kyber512X25519(),
+		hybrid.Kyber768X25519(),
+	} {
+		run(scheme, true, true, false, false)
+		run(scheme, true, false, false, false)
+		run(scheme, false, true, false, false)
+		run(scheme, true, true, true, false)
+		run(scheme, true, true, false, true)
+		run(scheme, true, true, true, true)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/quic-go/qtls-go1-20
 go 1.20
 
 require (
+	github.com/cloudflare/circl v1.2.1-0.20220809205628-0a9554f37a47
 	golang.org/x/crypto v0.4.0
 	golang.org/x/sys v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,16 @@
+github.com/bwesterb/go-ristretto v1.2.2/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/cloudflare/circl v1.2.1-0.20220809205628-0a9554f37a47 h1:YzpECHxZ9TzO7LpnKmPxItSd79lLgrR5heIlnqU4dTU=
+github.com/cloudflare/circl v1.2.1-0.20220809205628-0a9554f37a47/go.mod h1:qhx8gBILsYlbam7h09SvHDSkjpe3TfLA7b/z4rxJvkE=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.4.0 h1:UVQgzMY87xqpKNgb+kDsll2Igd33HszWHFLmpaRMq/8=
 golang.org/x/crypto v0.4.0/go.mod h1:3quD/ATkf6oY+rnes5c3ExXTbLc8mueNue5/DoinL80=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"crypto"
-	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
@@ -40,7 +39,7 @@ type clientHandshakeState struct {
 
 var testingOnlyForceClientHelloSignatureAlgorithms []SignatureScheme
 
-func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
+func (c *Conn) makeClientHello() (*clientHelloMsg, clientKeySharePrivate, error) {
 	config := c.config
 	if len(config.ServerName) == 0 && !config.InsecureSkipVerify {
 		return nil, nil, errors.New("tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config")
@@ -133,7 +132,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
 		hello.supportedSignatureAlgorithms = testingOnlyForceClientHelloSignatureAlgorithms
 	}
 
-	var key *ecdh.PrivateKey
+	var secret clientKeySharePrivate
 	if hello.supportedVersions[0] == VersionTLS13 {
 		if len(hello.supportedVersions) == 1 {
 			hello.cipherSuites = hello.cipherSuites[:0]
@@ -145,14 +144,30 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
 		}
 
 		curveID := config.curvePreferences()[0]
-		if _, ok := curveForCurveID(curveID); !ok {
-			return nil, nil, errors.New("tls: CurvePreferences includes unsupported curve")
+		if scheme := curveIdToCirclScheme(curveID); scheme != nil {
+			pk, sk, err := generateKemKeyPair(scheme, config.rand())
+			if err != nil {
+				return nil, nil, fmt.Errorf("generateKemKeyPair %s: %w",
+					scheme.Name(), err)
+			}
+			packedPk, err := pk.MarshalBinary()
+			if err != nil {
+				return nil, nil, fmt.Errorf("pack circl public key %s: %w",
+					scheme.Name(), err)
+			}
+			hello.keyShares = []keyShare{{group: curveID, data: packedPk}}
+			secret = sk
+		} else {
+			if _, ok := curveForCurveID(curveID); !ok {
+				return nil, nil, errors.New("tls: CurvePreferences includes unsupported curve")
+			}
+			key, err := generateECDHEKey(config.rand(), curveID)
+			if err != nil {
+				return nil, nil, err
+			}
+			hello.keyShares = []keyShare{{group: curveID, data: key.PublicKey().Bytes()}}
+			secret = key
 		}
-		key, err = generateECDHEKey(config.rand(), curveID)
-		if err != nil {
-			return nil, nil, err
-		}
-		hello.keyShares = []keyShare{{group: curveID, data: key.PublicKey().Bytes()}}
 	}
 
 	if c.quic != nil {
@@ -166,7 +181,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
 		hello.quicTransportParameters = p
 	}
 
-	return hello, key, nil
+	return hello, secret, nil
 }
 
 func (c *Conn) clientHandshake(ctx context.Context) (err error) {
@@ -246,14 +261,14 @@ func (c *Conn) clientHandshake(ctx context.Context) (err error) {
 
 	if c.vers == VersionTLS13 {
 		hs := &clientHandshakeStateTLS13{
-			c:           c,
-			ctx:         ctx,
-			serverHello: serverHello,
-			hello:       hello,
-			ecdheKey:    ecdheKey,
-			session:     session,
-			earlySecret: earlySecret,
-			binderKey:   binderKey,
+			c:               c,
+			ctx:             ctx,
+			serverHello:     serverHello,
+			hello:           hello,
+			keySharePrivate: ecdheKey,
+			session:         session,
+			earlySecret:     earlySecret,
+			binderKey:       binderKey,
 		}
 
 		// In TLS 1.3, session tickets are delivered after the handshake.

--- a/handshake_client_tls13.go
+++ b/handshake_client_tls13.go
@@ -13,18 +13,20 @@ import (
 	"crypto/rsa"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"hash"
 	"time"
 
+	circlKem "github.com/cloudflare/circl/kem"
 	"golang.org/x/crypto/cryptobyte"
 )
 
 type clientHandshakeStateTLS13 struct {
-	c           *Conn
-	ctx         context.Context
-	serverHello *serverHelloMsg
-	hello       *clientHelloMsg
-	ecdheKey    *ecdh.PrivateKey
+	c               *Conn
+	ctx             context.Context
+	serverHello     *serverHelloMsg
+	hello           *clientHelloMsg
+	keySharePrivate clientKeySharePrivate
 
 	session     *clientSessionState
 	earlySecret []byte
@@ -44,6 +46,8 @@ type clientHandshakeStateTLS13 struct {
 func (hs *clientHandshakeStateTLS13) handshake() error {
 	c := hs.c
 
+	startTime := time.Now()
+
 	if needFIPS() {
 		return errors.New("tls: internal error: TLS 1.3 reached in FIPS mode")
 	}
@@ -56,7 +60,7 @@ func (hs *clientHandshakeStateTLS13) handshake() error {
 	}
 
 	// Consistency check on the presence of a keyShare and its parameters.
-	if hs.ecdheKey == nil || len(hs.hello.keyShares) != 1 {
+	if hs.keySharePrivate == nil || len(hs.hello.keyShares) != 1 {
 		return c.sendAlert(alertInternalError)
 	}
 
@@ -111,6 +115,12 @@ func (hs *clientHandshakeStateTLS13) handshake() error {
 	if _, err := c.flush(); err != nil {
 		return err
 	}
+
+	raiseCFEvent(&cfEventHandshake{
+		serverSide: false,
+		duration:   time.Since(startTime),
+		kex:        hs.serverHello.serverShare.group,
+	})
 
 	c.isHandshakeComplete.Store(true)
 
@@ -191,6 +201,8 @@ func (hs *clientHandshakeStateTLS13) sendDummyChangeCipherSpec() error {
 func (hs *clientHandshakeStateTLS13) processHelloRetryRequest() error {
 	c := hs.c
 
+	raiseCFEvent(&cfEventHRR{serverSide: false})
+
 	// The first ClientHello gets double-hashed into the transcript upon a
 	// HelloRetryRequest. (The idea is that the server might offload transcript
 	// storage to the client in the cookie.) See RFC 8446, Section 4.4.1.
@@ -234,21 +246,38 @@ func (hs *clientHandshakeStateTLS13) processHelloRetryRequest() error {
 			c.sendAlert(alertIllegalParameter)
 			return errors.New("tls: server selected unsupported group")
 		}
-		if sentID, _ := curveIDForCurve(hs.ecdheKey.Curve()); sentID == curveID {
+		if clientKeySharePrivateCurveID(hs.keySharePrivate) == curveID {
 			c.sendAlert(alertIllegalParameter)
 			return errors.New("tls: server sent an unnecessary HelloRetryRequest key_share")
 		}
-		if _, ok := curveForCurveID(curveID); !ok {
-			c.sendAlert(alertInternalError)
-			return errors.New("tls: CurvePreferences includes unsupported curve")
+		if scheme := curveIdToCirclScheme(curveID); scheme != nil {
+			pk, sk, err := generateKemKeyPair(scheme, c.config.rand())
+			if err != nil {
+				c.sendAlert(alertInternalError)
+				return fmt.Errorf("HRR generateKeyPair %s: %w",
+					scheme.Name(), err)
+			}
+			packedPk, err := pk.MarshalBinary()
+			if err != nil {
+				c.sendAlert(alertInternalError)
+				return fmt.Errorf("HRR pack circl public key %s: %w",
+					scheme.Name(), err)
+			}
+			hs.keySharePrivate = sk
+			hs.hello.keyShares = []keyShare{{group: curveID, data: packedPk}}
+		} else {
+			if _, ok := curveForCurveID(curveID); !ok {
+				c.sendAlert(alertInternalError)
+				return errors.New("tls: CurvePreferences includes unsupported curve")
+			}
+			key, err := generateECDHEKey(c.config.rand(), curveID)
+			if err != nil {
+				c.sendAlert(alertInternalError)
+				return err
+			}
+			hs.keySharePrivate = key
+			hs.hello.keyShares = []keyShare{{group: curveID, data: key.PublicKey().Bytes()}}
 		}
-		key, err := generateECDHEKey(c.config.rand(), curveID)
-		if err != nil {
-			c.sendAlert(alertInternalError)
-			return err
-		}
-		hs.ecdheKey = key
-		hs.hello.keyShares = []keyShare{{group: curveID, data: key.PublicKey().Bytes()}}
 	}
 
 	hs.hello.raw = nil
@@ -335,7 +364,7 @@ func (hs *clientHandshakeStateTLS13) processServerHello() error {
 		c.sendAlert(alertIllegalParameter)
 		return errors.New("tls: server did not send a key share")
 	}
-	if sentID, _ := curveIDForCurve(hs.ecdheKey.Curve()); hs.serverHello.serverShare.group != sentID {
+	if hs.serverHello.serverShare.group != clientKeySharePrivateCurveID(hs.keySharePrivate) {
 		c.sendAlert(alertIllegalParameter)
 		return errors.New("tls: server selected unsupported group")
 	}
@@ -373,13 +402,22 @@ func (hs *clientHandshakeStateTLS13) processServerHello() error {
 func (hs *clientHandshakeStateTLS13) establishHandshakeKeys() error {
 	c := hs.c
 
-	peerKey, err := hs.ecdheKey.Curve().NewPublicKey(hs.serverHello.serverShare.data)
-	if err != nil {
-		c.sendAlert(alertIllegalParameter)
-		return errors.New("tls: invalid server key share")
+	var sharedKey []byte
+	var err error
+	if key, ok := hs.keySharePrivate.(*ecdh.PrivateKey); ok {
+		peerKey, err := key.Curve().NewPublicKey(hs.serverHello.serverShare.data)
+		if err == nil {
+			sharedKey, _ = key.ECDH(peerKey)
+		}
+	} else if sk, ok := hs.keySharePrivate.(circlKem.PrivateKey); ok {
+		sharedKey, err = sk.Scheme().Decapsulate(sk, hs.serverHello.serverShare.data)
+		if err != nil {
+			c.sendAlert(alertIllegalParameter)
+			return fmt.Errorf("%s decaps: %w", sk.Scheme().Name(), err)
+		}
 	}
-	sharedKey, err := hs.ecdheKey.ECDH(peerKey)
-	if err != nil {
+
+	if sharedKey == nil {
 		c.sendAlert(alertIllegalParameter)
 		return errors.New("tls: invalid server key share")
 	}

--- a/handshake_server_tls13.go
+++ b/handshake_server_tls13.go
@@ -11,6 +11,7 @@ import (
 	"crypto/hmac"
 	"crypto/rsa"
 	"errors"
+	"fmt"
 	"hash"
 	"io"
 	"time"
@@ -45,6 +46,8 @@ type serverHandshakeStateTLS13 struct {
 
 func (hs *serverHandshakeStateTLS13) handshake() error {
 	c := hs.c
+
+	startTime := time.Now()
 
 	if needFIPS() {
 		return errors.New("tls: internal error: TLS 1.3 reached in FIPS mode")
@@ -82,6 +85,12 @@ func (hs *serverHandshakeStateTLS13) handshake() error {
 	if err := hs.readClientFinished(); err != nil {
 		return err
 	}
+
+	raiseCFEvent(&cfEventHandshake{
+		serverSide: true,
+		duration:   time.Since(startTime),
+		kex:        hs.hello.serverShare.group,
+	})
 
 	c.isHandshakeComplete.Store(true)
 
@@ -197,23 +206,31 @@ GroupSelection:
 		clientKeyShare = &hs.clientHello.keyShares[0]
 	}
 
-	if _, ok := curveForCurveID(selectedGroup); !ok {
+	if _, ok := curveForCurveID(selectedGroup); curveIdToCirclScheme(selectedGroup) == nil && !ok {
 		c.sendAlert(alertInternalError)
 		return errors.New("tls: CurvePreferences includes unsupported curve")
 	}
-	key, err := generateECDHEKey(c.config.rand(), selectedGroup)
-	if err != nil {
-		c.sendAlert(alertInternalError)
-		return err
+	if kem := curveIdToCirclScheme(selectedGroup); kem != nil {
+		ct, ss, alert, err := encapsulateForKem(kem, c.config.rand(), clientKeyShare.data)
+		if err != nil {
+			c.sendAlert(alert)
+			return fmt.Errorf("%s encap: %w", kem.Name(), err)
+		}
+		hs.hello.serverShare = keyShare{group: selectedGroup, data: ct}
+		hs.sharedKey = ss
+	} else {
+		key, err := generateECDHEKey(c.config.rand(), selectedGroup)
+		if err != nil {
+			c.sendAlert(alertInternalError)
+			return err
+		}
+		hs.hello.serverShare = keyShare{group: selectedGroup, data: key.PublicKey().Bytes()}
+		peerKey, err := key.Curve().NewPublicKey(clientKeyShare.data)
+		if err == nil {
+			hs.sharedKey, _ = key.ECDH(peerKey)
+		}
 	}
-	hs.hello.serverShare = keyShare{group: selectedGroup, data: key.PublicKey().Bytes()}
-	peerKey, err := key.Curve().NewPublicKey(clientKeyShare.data)
-	if err != nil {
-		c.sendAlert(alertIllegalParameter)
-		return errors.New("tls: invalid client key share")
-	}
-	hs.sharedKey, err = key.ECDH(peerKey)
-	if err != nil {
+	if hs.sharedKey == nil {
 		c.sendAlert(alertIllegalParameter)
 		return errors.New("tls: invalid client key share")
 	}
@@ -449,6 +466,8 @@ func (hs *serverHandshakeStateTLS13) sendDummyChangeCipherSpec() error {
 
 func (hs *serverHandshakeStateTLS13) doHelloRetryRequest(selectedGroup CurveID) error {
 	c := hs.c
+
+	raiseCFEvent(&cfEventHRR{serverSide: true})
 
 	// The first ClientHello gets double-hashed into the transcript upon a
 	// HelloRetryRequest. See RFC 8446, Section 4.4.1.

--- a/key_agreement.go
+++ b/key_agreement.go
@@ -169,7 +169,7 @@ type ecdheKeyAgreement struct {
 func (ka *ecdheKeyAgreement) generateServerKeyExchange(config *config, cert *Certificate, clientHello *clientHelloMsg, hello *serverHelloMsg) (*serverKeyExchangeMsg, error) {
 	var curveID CurveID
 	for _, c := range clientHello.supportedCurves {
-		if config.supportsCurve(c) {
+		if config.supportsCurve(c) && curveIdToCirclScheme(c) == nil {
 			curveID = c
 			break
 		}


### PR DESCRIPTION
Rebase on 1.20 v0.4.0

Will force push to go1.20 branch.

```
$ git range-diff go1.20^..go1.20 bas/go1.20/v0.4.0^..bas/go1.20/v0.4.0
1:  c14f741 ! 1:  5b458bc RTG-2051 Add X25519Kyber{512,768}Draft00 hybrid post-quantum key exchange
    @@ cfkem_test.go (new)
     +
     +	go func() {
     +		defer s.Close()
    -+		done <- Server(s, serverConfig, nil).Handshake()
    ++		done <- Server(s, serverConfig).Handshake()
     +	}()
     +
    -+	cli := Client(c, clientConfig, nil)
    ++	cli := Client(c, clientConfig)
     +	clientErr := cli.Handshake()
     +	serverErr := <-done
     +	if clientErr != nil {
    @@ go.mod: module github.com/quic-go/qtls-go1-20
      
      require (
     +	github.com/cloudflare/circl v1.2.1-0.20220809205628-0a9554f37a47
    - 	github.com/golang/mock v1.6.0
      	golang.org/x/crypto v0.4.0
      	golang.org/x/sys v0.3.0
    + )
     
      ## go.sum ##
     @@
     +github.com/bwesterb/go-ristretto v1.2.2/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
     +github.com/cloudflare/circl v1.2.1-0.20220809205628-0a9554f37a47 h1:YzpECHxZ9TzO7LpnKmPxItSd79lLgrR5heIlnqU4dTU=
     +github.com/cloudflare/circl v1.2.1-0.20220809205628-0a9554f37a47/go.mod h1:qhx8gBILsYlbam7h09SvHDSkjpe3TfLA7b/z4rxJvkE=
    - github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
    - github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
    - github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
    - golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
    - golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
     +golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
      golang.org/x/crypto v0.4.0 h1:UVQgzMY87xqpKNgb+kDsll2Igd33HszWHFLmpaRMq/8=
      golang.org/x/crypto v0.4.0/go.mod h1:3quD/ATkf6oY+rnes5c3ExXTbLc8mueNue5/DoinL80=
    - golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
    - golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
    - golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
    - golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
     +golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
    - golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
    - golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
    - golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
    - golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
    - golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
    - golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
    ++golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
     +golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
    - golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
     +golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
     +golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
      golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
      golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
    - golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
    - golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
    - golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
    ++golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
     +golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
    - golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
    - golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
    - golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
    ++golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
     
      ## handshake_client.go ##
     @@ handshake_client.go: import (
    @@ handshake_client.go: func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.Pr
     -	var key *ecdh.PrivateKey
     +	var secret clientKeySharePrivate
      	if hello.supportedVersions[0] == VersionTLS13 {
    - 		var suites []uint16
    - 		for _, suiteID := range configCipherSuites {
    + 		if len(hello.supportedVersions) == 1 {
    + 			hello.cipherSuites = hello.cipherSuites[:0]
     @@ handshake_client.go: func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
      		}
      
    @@ handshake_client.go: func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.Pr
     -		hello.keyShares = []keyShare{{group: curveID, data: key.PublicKey().Bytes()}}
      	}
      
    - 	if hello.supportedVersions[0] == VersionTLS13 && c.extraConfig != nil && c.extraConfig.GetExtensions != nil {
    - 		hello.additionalExtensions = c.extraConfig.GetExtensions(typeClientHello)
    + 	if c.quic != nil {
    +@@ handshake_client.go: func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
    + 		hello.quicTransportParameters = p
      	}
      
     -	return hello, key, nil
    @@ handshake_client_tls13.go: func (hs *clientHandshakeStateTLS13) handshake() erro
     +	})
     +
      	c.isHandshakeComplete.Store(true)
    - 	c.updateConnectionState()
    + 
      	return nil
     @@ handshake_client_tls13.go: func (hs *clientHandshakeStateTLS13) sendDummyChangeCipherSpec() error {
      func (hs *clientHandshakeStateTLS13) processHelloRetryRequest() error {
    @@ handshake_server_tls13.go: func (hs *serverHandshakeStateTLS13) handshake() erro
     +	})
     +
      	c.isHandshakeComplete.Store(true)
    - 	c.updateConnectionState()
    + 
      	return nil
     @@ handshake_server_tls13.go: GroupSelection:
      		clientKeyShare = &hs.clientHello.keyShares[0]

```